### PR TITLE
fix(windowparameter): Rename glazingparameter to windowparameter

### DIFF
--- a/tests/building_extend_test.py
+++ b/tests/building_extend_test.py
@@ -2,7 +2,7 @@
 from dragonfly.building import Building
 from dragonfly.story import Story
 from dragonfly.room2d import Room2D
-from dragonfly.glazingparameter import SimpleGlazingRatio
+from dragonfly.windowparameter import SimpleWindowRatio
 
 from dragonfly_energy.properties.building import BuildingEnergyProperties
 
@@ -29,7 +29,7 @@ def test_building_init():
     room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
     story = Story('Office Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
     story.solve_room_2d_adjacency(0.01)
-    story.set_outdoor_glazing_parameters(SimpleGlazingRatio(0.4))
+    story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story.multiplier = 4
     building = Building('Office Building', [story])
 
@@ -50,7 +50,7 @@ def test_set_construction_set():
     room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
     story = Story('Office Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
     story.solve_room_2d_adjacency(0.01)
-    story.set_outdoor_glazing_parameters(SimpleGlazingRatio(0.4))
+    story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story.multiplier = 4
     building = Building('Office Building', [story])
 
@@ -88,7 +88,7 @@ def test_set_all_room_2d_program_type():
     room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
     story = Story('Office Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
     story.solve_room_2d_adjacency(0.01)
-    story.set_outdoor_glazing_parameters(SimpleGlazingRatio(0.4))
+    story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story.multiplier = 4
     building = Building('Office Building', [story])
 
@@ -117,7 +117,7 @@ def test_set_all_room_2d_hvac():
     room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
     story = Story('Office Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
     story.solve_room_2d_adjacency(0.01)
-    story.set_outdoor_glazing_parameters(SimpleGlazingRatio(0.4))
+    story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story.multiplier = 4
     building = Building('Office Building', [story])
 
@@ -149,7 +149,7 @@ def test_duplicate():
     room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
     story = Story('Office Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
     story.solve_room_2d_adjacency(0.01)
-    story.set_outdoor_glazing_parameters(SimpleGlazingRatio(0.4))
+    story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story.multiplier = 4
     building_original = Building('Office Building', [story])
     building_dup_1 = building_original.duplicate()
@@ -187,7 +187,7 @@ def test_to_dict():
     room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
     story = Story('Office Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
     story.solve_room_2d_adjacency(0.01)
-    story.set_outdoor_glazing_parameters(SimpleGlazingRatio(0.4))
+    story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story.multiplier = 4
     building = Building('Office Building', [story])
 
@@ -216,7 +216,7 @@ def test_from_dict():
     room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
     story = Story('Office Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
     story.solve_room_2d_adjacency(0.01)
-    story.set_outdoor_glazing_parameters(SimpleGlazingRatio(0.4))
+    story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story.multiplier = 4
     building = Building('Office Building', [story])
 

--- a/tests/room2d_extend_test.py
+++ b/tests/room2d_extend_test.py
@@ -1,6 +1,6 @@
 """Tests the features that dragonfly_energy adds to dragonfly_core Room2D."""
 from dragonfly.room2d import Room2D
-from dragonfly.glazingparameter import SimpleGlazingRatio
+from dragonfly.windowparameter import SimpleWindowRatio
 from dragonfly.shadingparameter import Overhang
 
 from dragonfly_energy.properties.room2d import Room2DEnergyProperties
@@ -27,12 +27,12 @@ from ladybug.dt import Time
 def test_energy_properties():
     """Test the existence of the Room2D energy properties."""
     pts = (Point3D(0, 0, 3), Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3))
-    ashrae_base = SimpleGlazingRatio(0.4)
+    ashrae_base = SimpleWindowRatio(0.4)
     overhang = Overhang(1)
     boundarycs = (bcs.outdoors, bcs.ground, bcs.outdoors, bcs.ground)
-    glazing = (ashrae_base, None, ashrae_base, None)
+    window = (ashrae_base, None, ashrae_base, None)
     shading = (overhang, None, None, None)
-    room = Room2D('Square Shoebox', Face3D(pts), 3, boundarycs, glazing, shading)
+    room = Room2D('Square Shoebox', Face3D(pts), 3, boundarycs, window, shading)
 
     room.properties.energy.program_type = office_program
     room.properties.energy.hvac = IdealAirSystem()
@@ -49,9 +49,9 @@ def test_energy_properties():
 def test_default_properties():
     """Test the auto-assigning of Room2D properties."""
     pts = (Point3D(0, 0, 3), Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3))
-    ashrae_base = SimpleGlazingRatio(0.4)
+    ashrae_base = SimpleWindowRatio(0.4)
     room = Room2D('Square Shoebox', Face3D(pts), 3)
-    room.set_outdoor_glazing_parameters(ashrae_base)
+    room.set_outdoor_window_parameters(ashrae_base)
 
     assert room.properties.energy.construction_set.name == \
         'Default Generic Construction Set'
@@ -63,12 +63,12 @@ def test_default_properties():
 def test_set_construction_set():
     """Test the setting of a ConstructionSet on a Room2D."""
     pts = (Point3D(0, 0, 3), Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3))
-    ashrae_base = SimpleGlazingRatio(0.4)
+    ashrae_base = SimpleWindowRatio(0.4)
     overhang = Overhang(1)
     boundarycs = (bcs.outdoors, bcs.ground, bcs.outdoors, bcs.ground)
-    glazing = (ashrae_base, None, ashrae_base, None)
+    window = (ashrae_base, None, ashrae_base, None)
     shading = (overhang, None, None, None)
-    room = Room2D('Square Shoebox', Face3D(pts), 3, boundarycs, glazing, shading)
+    room = Room2D('Square Shoebox', Face3D(pts), 3, boundarycs, window, shading)
 
     mass_set = ConstructionSet('Thermal Mass Construction Set')
     concrete20 = EnergyMaterial('20cm Concrete', 0.2, 2.31, 2322, 832,
@@ -112,9 +112,9 @@ def test_set_program_type():
     lab_program.ventilation.schedule = lab_ventilation
 
     pts = (Point3D(0, 0, 3), Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3))
-    ashrae_base = SimpleGlazingRatio(0.4)
+    ashrae_base = SimpleWindowRatio(0.4)
     room = Room2D('Square Shoebox', Face3D(pts), 3)
-    room.set_outdoor_glazing_parameters(ashrae_base)
+    room.set_outdoor_window_parameters(ashrae_base)
 
     room.properties.energy.program_type = lab_program
 
@@ -133,9 +133,9 @@ def test_set_program_type():
 def test_set_ideal_air():
     """Test the setting of a IdealAirSystems on a Room2D."""
     pts = (Point3D(0, 0, 3), Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3))
-    ashrae_base = SimpleGlazingRatio(0.4)
+    ashrae_base = SimpleWindowRatio(0.4)
     room = Room2D('Square Shoebox', Face3D(pts), 3)
-    room.set_outdoor_glazing_parameters(ashrae_base)
+    room.set_outdoor_window_parameters(ashrae_base)
 
     sensible = 0.8
     latent = 0.7
@@ -158,9 +158,9 @@ def test_duplicate():
     """Test what happens to energy properties when duplicating a Room2D."""
     mass_set = ConstructionSet('Thermal Mass Construction Set')
     pts = (Point3D(0, 0, 3), Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3))
-    ashrae_base = SimpleGlazingRatio(0.4)
+    ashrae_base = SimpleWindowRatio(0.4)
     room_original = Room2D('Square Shoebox', Face3D(pts), 3)
-    room_original.set_outdoor_glazing_parameters(ashrae_base)
+    room_original.set_outdoor_window_parameters(ashrae_base)
     room_dup_1 = room_original.duplicate()
 
     assert room_original.properties.energy.host is room_original
@@ -187,9 +187,9 @@ def test_to_dict():
     """Test the Room2D to_dict method with energy properties."""
     mass_set = ConstructionSet('Thermal Mass Construction Set')
     pts = (Point3D(0, 0, 3), Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3))
-    ashrae_base = SimpleGlazingRatio(0.4)
+    ashrae_base = SimpleWindowRatio(0.4)
     room = Room2D('Square Shoebox', Face3D(pts), 3)
-    room.set_outdoor_glazing_parameters(ashrae_base)
+    room.set_outdoor_window_parameters(ashrae_base)
 
     rd = room.to_dict()
     assert 'properties' in rd
@@ -211,9 +211,9 @@ def test_to_dict():
 def test_from_dict():
     """Test the Room2D from_dict method with energy properties."""
     pts = (Point3D(0, 0, 3), Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3))
-    ashrae_base = SimpleGlazingRatio(0.4)
+    ashrae_base = SimpleWindowRatio(0.4)
     room = Room2D('Square Shoebox', Face3D(pts), 3)
-    room.set_outdoor_glazing_parameters(ashrae_base)
+    room.set_outdoor_window_parameters(ashrae_base)
 
     mass_set = ConstructionSet('Thermal Mass Construction Set')
     room.properties.energy.construction_set = mass_set

--- a/tests/story_extend_test.py
+++ b/tests/story_extend_test.py
@@ -1,7 +1,7 @@
 """Tests the features that dragonfly_energy adds to dragonfly_core Story."""
 from dragonfly.story import Story
 from dragonfly.room2d import Room2D
-from dragonfly.glazingparameter import SimpleGlazingRatio
+from dragonfly.windowparameter import SimpleWindowRatio
 
 from dragonfly_energy.properties.story import StoryEnergyProperties
 
@@ -28,7 +28,7 @@ def test_energy_properties():
     room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
     story = Story('Office Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
     story.solve_room_2d_adjacency(0.01)
-    story.set_outdoor_glazing_parameters(SimpleGlazingRatio(0.4))
+    story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
 
     assert hasattr(story.properties, 'energy')
     assert isinstance(story.properties.energy, StoryEnergyProperties)
@@ -47,7 +47,7 @@ def test_set_construction_set():
     room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
     story = Story('Office Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
     story.solve_room_2d_adjacency(0.01)
-    story.set_outdoor_glazing_parameters(SimpleGlazingRatio(0.4))
+    story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
 
     mass_set = ConstructionSet('Thermal Mass Construction Set')
     concrete20 = EnergyMaterial('20cm Concrete', 0.2, 2.31, 2322, 832,
@@ -83,7 +83,7 @@ def test_set_all_room_2d_program_type():
     room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
     story = Story('Office Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
     story.solve_room_2d_adjacency(0.01)
-    story.set_outdoor_glazing_parameters(SimpleGlazingRatio(0.4))
+    story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
 
     lab_program = office_program.duplicate()
     lab_program.name = 'Bio Laboratory'
@@ -110,7 +110,7 @@ def test_set_all_room_2d_hvac():
     room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
     story = Story('Office Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
     story.solve_room_2d_adjacency(0.01)
-    story.set_outdoor_glazing_parameters(SimpleGlazingRatio(0.4))
+    story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
 
     sensible = 0.8
     latent = 0.7
@@ -140,7 +140,7 @@ def test_duplicate():
     room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
     story_original = Story('Office Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
     story_original.solve_room_2d_adjacency(0.01)
-    story_original.set_outdoor_glazing_parameters(SimpleGlazingRatio(0.4))
+    story_original.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story_dup_1 = story_original.duplicate()
 
     assert story_original.properties.energy.host is story_original
@@ -176,7 +176,7 @@ def test_to_dict():
     room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
     story = Story('Office Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
     story.solve_room_2d_adjacency(0.01)
-    story.set_outdoor_glazing_parameters(SimpleGlazingRatio(0.4))
+    story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
 
     sd = story.to_dict()
     assert 'properties' in sd
@@ -203,7 +203,7 @@ def test_from_dict():
     room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
     story = Story('Office Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
     story.solve_room_2d_adjacency(0.01)
-    story.set_outdoor_glazing_parameters(SimpleGlazingRatio(0.4))
+    story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
 
     mass_set = ConstructionSet('Thermal Mass Construction Set')
     story.properties.energy.construction_set = mass_set


### PR DESCRIPTION
We want to be clear in our vocabulary now that we use the term Aperture" and no longer use the term "Glazing". We will, however, use the term "Window" to refer to Apertures (usually in Walls) that aren't anything special like a light tube, daylight dome, etc. Another way to phrase this is as those apertures using EnergyPlus Window Constructions and.or Radiance glass materials.