### PR TITLE
fix(default): Do not use mutable objects for input argument defaults

### DIFF
--- a/dragonfly_energy/properties/model.py
+++ b/dragonfly_energy/properties/model.py
@@ -291,7 +291,7 @@ class ModelEnergyProperties(object):
 
         # collect lists of energy property dictionaries
         building_e_dicts, story_e_dicts, room2d_e_dicts, context_e_dicts = \
-            model_extension_dicts(data, 'energy')
+            model_extension_dicts(data, 'energy', [], [], [], [])
 
         # apply energy properties to objects using the energy property dictionaries
         for bldg, b_dict in zip(self.host.buildings, building_e_dicts):

--- a/tests/building_extend_test.py
+++ b/tests/building_extend_test.py
@@ -29,7 +29,6 @@ from ladybug.dt import Time
 from ladybug_geometry.geometry3d.pointvector import Point3D
 from ladybug_geometry.geometry3d.face import Face3D
 
-import json
 import pytest
 
 
@@ -337,40 +336,3 @@ def test_from_dict():
     assert new_bldg.properties.energy.construction_set.name == \
         'Thermal Mass Construction Set'
     assert new_bldg.to_dict() == bd
-
-
-def test_to_dict_revit():
-    """Test the to_dict method in a way that mimics how the export from Revit happens."""
-    pts_1 = (Point3D(0, 0, 0), Point3D(0, 10, 0), Point3D(10, 10, 0), Point3D(10, 0, 0))
-    pts_2 = (Point3D(10, 0, 0), Point3D(10, 10, 0), Point3D(20, 10, 0), Point3D(20, 0, 0))
-    pts_3 = (Point3D(0, 10, 0), Point3D(0, 20, 0), Point3D(10, 20, 0), Point3D(10, 10, 0))
-    pts_4 = (Point3D(10, 10, 0), Point3D(10, 20, 0), Point3D(20, 20, 0), Point3D(20, 10, 0))
-    pts_5 = (Point3D(0, 0, 3), Point3D(0, 10, 3), Point3D(10, 10, 3), Point3D(10, 0, 3))
-    pts_6 = (Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(20, 10, 3), Point3D(20, 0, 3))
-    pts_7 = (Point3D(0, 0, 6), Point3D(0, 10, 6), Point3D(10, 10, 6), Point3D(10, 0, 6))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    room2d_3 = Room2D('Office 3', Face3D(pts_3), 3)
-    room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
-    room2d_5 = Room2D('Office 5', Face3D(pts_5), 3)
-    room2d_6 = Room2D('Office 6', Face3D(pts_6), 3)
-    room2d_7 = Room2D('Office 7', Face3D(pts_7), 3)
-    story_1 = Story('Office Floor 1', [room2d_1, room2d_2, room2d_3, room2d_4])
-    story_2 = Story('Office Floor 2', [room2d_5, room2d_6])
-    story_3 = Story('Office Floor 3', [room2d_7])
-    story_1.solve_room_2d_adjacency(0.01)
-    story_2.solve_room_2d_adjacency(0.01)
-    story_1.set_outdoor_window_parameters(SimpleWindowRatio(0.3))
-    story_2.set_outdoor_window_parameters(SimpleWindowRatio(0.35))
-    story_3.set_outdoor_window_parameters(SimpleWindowRatio(0.6))
-    building = Building('Office Building', [story_1, story_2, story_3])
-    building.separate_top_bottom_floors()
-
-    building.to_dict()
-    """
-    f_dir = 'C:/Users/chris/Documents/GitHub/dragonfly-schema/dragonfly_schema/' \
-        'samples'
-    dest_file = f_dir + '/building_simple.json'
-    with open(dest_file, 'w') as fp:
-        json.dump(building.to_dict(True), fp, indent=4)
-    """

--- a/tests/context_extend_test.py
+++ b/tests/context_extend_test.py
@@ -12,8 +12,6 @@ from ladybug_geometry.geometry3d.pointvector import Point3D
 from ladybug_geometry.geometry3d.plane import Plane
 from ladybug_geometry.geometry3d.face import Face3D
 
-import json
-
 
 def test_energy_properties():
     """Test the existence of the ContextShade energy properties."""
@@ -42,14 +40,6 @@ def test_set_construction_schedule():
 
     assert tree_canopy.properties.energy.construction == bright_leaves
     assert tree_canopy.properties.energy.transmittance_schedule == tree_trans
-
-    """
-    f_dir = 'C:/Users/chris/Documents/GitHub/dragonfly-schema/dragonfly_schema/' \
-        'samples'
-    dest_file = f_dir + '/context_shade_two_tree_canopy.json'
-    with open(dest_file, 'w') as fp:
-        json.dump(tree_canopy.to_dict(True), fp, indent=4)
-    """
 
 
 def test_duplicate():

--- a/tests/model_extend_test.py
+++ b/tests/model_extend_test.py
@@ -36,8 +36,6 @@ from ladybug_geometry.geometry3d.pointvector import Point3D, Vector3D
 from ladybug_geometry.geometry3d.plane import Plane
 from ladybug_geometry.geometry3d.face import Face3D
 
-import json
-
 
 def test_energy_properties():
     """Test the existence of the Model energy properties."""
@@ -236,14 +234,6 @@ def test_to_from_dict():
     assert tree_trans in new_model.properties.energy.schedules
     assert new_model.context_shades[0].properties.energy.construction == bright_leaves
     assert new_model.context_shades[0].properties.energy.transmittance_schedule == tree_trans
-
-    """
-    f_dir = 'C:/Users/chris/Documents/GitHub/dragonfly-schema/dragonfly_schema/' \
-        'samples'
-    dest_file = f_dir + '/model_complete_simple.json'
-    with open(dest_file, 'w') as fp:
-        json.dump(model_dict, fp, indent=4)
-    """
 
 
 def test_to_honeybee():

--- a/tests/room2d_extend_test.py
+++ b/tests/room2d_extend_test.py
@@ -23,8 +23,6 @@ from ladybug_geometry.geometry3d.face import Face3D
 
 from ladybug.dt import Time
 
-import json
-
 
 def test_energy_properties():
     """Test the existence of the Room2D energy properties."""
@@ -213,14 +211,6 @@ def test_to_dict():
     rd = room.to_dict()
     assert rd['properties']['energy']['construction_set'] is not None
     assert rd['properties']['energy']['program_type'] is not None
-
-    """
-    f_dir = 'C:/Users/chris/Documents/GitHub/dragonfly-schema/dragonfly_schema/' \
-        'samples'
-    dest_file = f_dir + '/room2d_simple.json'
-    with open(dest_file, 'w') as fp:
-        json.dump(room.to_dict(True), fp, indent=4)
-    """
 
 
 def test_from_dict():

--- a/tests/story_extend_test.py
+++ b/tests/story_extend_test.py
@@ -15,8 +15,6 @@ from honeybee_energy.lib.programtypes import office_program
 from ladybug_geometry.geometry3d.pointvector import Point3D
 from ladybug_geometry.geometry3d.face import Face3D
 
-import json
-
 
 def test_energy_properties():
     """Test the existence of the Story energy properties."""
@@ -191,14 +189,6 @@ def test_to_dict():
     story.properties.energy.construction_set = mass_set
     sd = story.to_dict()
     assert sd['properties']['energy']['construction_set'] is not None
-
-    """
-    f_dir = 'C:/Users/chris/Documents/GitHub/dragonfly-schema/dragonfly_schema/' \
-        'samples'
-    dest_file = f_dir + '/story_simple.json'
-    with open(dest_file, 'w') as fp:
-        json.dump(story.to_dict(True), fp, indent=4)
-    """
 
 
 def test_from_dict():


### PR DESCRIPTION
This should temporarily fix a bug that found resulting form this bad practice. I'll still have to push a fix to dragonfly-core in order to nip it in the bud.