### PR TITLE
fix(model): Remove north from Model properties

### DIFF
--- a/dragonfly_energy/cli/translate.py
+++ b/dragonfly_energy/cli/translate.py
@@ -200,9 +200,7 @@ def model_to_idf(model_json, sim_par_json, obj_per_model, use_multiplier,
             ver_str = energyplus_idf_version() if folders.energyplus_version \
                 is not None else energyplus_idf_version((9, 2, 0))
             sim_par_str = sim_par.to_idf()
-            model_str = hb_model.to.idf(
-                hb_model, schedule_directory=sch_directory,
-                solar_distribution=sim_par.shadow_calculation.solar_distribution)
+            model_str = hb_model.to.idf(hb_model, schedule_directory=sch_directory)
             idf_str = '\n\n'.join([ver_str, sim_par_str, model_str])
 
             # write out the IDF file

--- a/dragonfly_energy/properties/model.py
+++ b/dragonfly_energy/properties/model.py
@@ -21,13 +21,9 @@ class ModelEnergyProperties(object):
 
     Args:
         host: A dragonfly_core Model object that hosts these properties.
-        terrain_type: Text for the terrain type in which the model sits.
-            Choose from: 'Ocean', 'Country', 'Suburbs', 'Urban', 'City'.
-            Default: 'City'.
 
     Properties:
         * host
-        * terrain_type
         * materials
         * constructions
         * shade_constructions
@@ -40,42 +36,15 @@ class ModelEnergyProperties(object):
         * hvac_schedules
         * program_types
     """
-    TERRAIN_TYPES = hb_model_properties.ModelEnergyProperties.TERRAIN_TYPES
 
-    def __init__(self, host, terrain_type='City'):
+    def __init__(self, host):
         """Initialize Model energy properties."""
         self._host = host
-        self.terrain_type = terrain_type
 
     @property
     def host(self):
         """Get the Model object hosting these properties."""
         return self._host
-
-    @property
-    def terrain_type(self):
-        """Get or set a text string for the terrain in which the model sits.
-
-        This is used to determine the wind profile over the height of the
-        building. Default is 'City'. Choose from the following options:
-
-        * Ocean
-        * Country
-        * Suburbs
-        * Urban
-        * City
-        """
-        return self._terrain_type
-
-    @terrain_type.setter
-    def terrain_type(self, value):
-        if value is not None:
-            assert value in self.TERRAIN_TYPES, 'Input terrain_type "{}" is ' \
-                'not valid. Choose from the following options:\n{}'.format(
-                    value, self.TERRAIN_TYPES)
-            self._terrain_type = value
-        else:
-            self._terrain_type = 'City'
 
     @property
     def materials(self):
@@ -281,11 +250,6 @@ class ModelEnergyProperties(object):
         """
         assert 'energy' in data['properties'], \
             'Dictionary possesses no ModelEnergyProperties.'
-
-        # set the terrain
-        if 'terrain_type' in data['properties']['energy']:
-            self.terrain_type = data['properties']['energy']['terrain_type']
-
         materials, constructions, construction_sets, schedule_type_limits, \
             schedules, program_types, hvacs = \
             hb_model_properties.ModelEnergyProperties.load_properties_from_dict(data)
@@ -317,9 +281,6 @@ class ModelEnergyProperties(object):
         """
         base = {'energy': {'type': 'ModelEnergyProperties'}}
 
-        # add the terrain
-        base['energy']['terrain_type'] = self.terrain_type
-
         # add all materials, constructions and construction sets to the dictionary
         schs = self._add_constr_type_objs_to_dict(base, include_global_construction_set)
 
@@ -334,7 +295,7 @@ class ModelEnergyProperties(object):
         Args:
             new_host: A honeybee-core Model object that will host these properties.
         """
-        return hb_model_properties.ModelEnergyProperties(new_host, self.terrain_type)
+        return hb_model_properties.ModelEnergyProperties(new_host)
 
     def duplicate(self, new_host=None):
         """Get a copy of this Model.
@@ -344,7 +305,7 @@ class ModelEnergyProperties(object):
                 If None, the properties will be duplicated with the same host.
         """
         _host = new_host or self._host
-        return ModelEnergyProperties(_host, self.terrain_type)
+        return ModelEnergyProperties(_host)
 
     def _add_constr_type_objs_to_dict(self, base, include_global_construction_set=True):
         """Add materials, constructions and construction sets to a base dictionary.
@@ -466,7 +427,7 @@ class ModelEnergyProperties(object):
     def _instance_in_array(object_instance, object_array):
         """Check if a specific object instance is already in an array.
 
-        This can be much faster than  `if object_instance in object_arrary`
+        This can be much faster than  `if object_instance in object_array`
         when you expect to be testing a lot of the same instance of an object for
         inclusion in an array since the builtin method uses an == operator to
         test inclusion.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-dragonfly-core==1.16.4
-honeybee-energy==1.41.6
+dragonfly-core==1.16.5
+honeybee-energy==1.41.7

--- a/tests/model_extend_test.py
+++ b/tests/model_extend_test.py
@@ -217,7 +217,6 @@ def test_to_from_dict():
 
     model = Model('NewDevelopment', [building], [tree_canopy])
 
-    model.north_angle = 15
     model_dict = model.to_dict()
     new_model = Model.from_dict(model_dict)
     assert model_dict == new_model.to_dict()


### PR DESCRIPTION
After some discussions with @mostaphaRoudsari , we have decided that the north should not be a property of the Model for the same reason why we don't have the location as a part of the model. The north direction is a property of the simulation assets like the skies used in Radiance or the simulation parameters used in our EnergyPlus.