### PR TITLE
feat(urbanopt): Refactor the running of URBANopt export and simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,66 @@ import dragonfly_energy
 
 ## [API Documentation](http://ladybug-tools.github.io/dragonfly-energy/docs)
 
+## Usage
+Since the building geometry in dragonfly is fundamentally 2D, creating a model of
+a building and assigning energy model properties can be done with a few lines of
+code. Here is an example:
+```
+from dragonfly.model import Model
+from dragonfly.building import Building
+from dragonfly.story import Story
+from dragonfly.room2d import Room2D
+from dragonfly.windowparameter import SimpleWindowRatio
+from honeybee_energy.lib.programtypes import office_program
+
+# create the Building object
+pts_1 = (Point3D(0, 0, 3), Point3D(0, 10, 3), Point3D(10, 10, 3), Point3D(10, 0, 3))
+pts_2 = (Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(20, 10, 3), Point3D(20, 0, 3))
+pts_3 = (Point3D(0, 10, 3), Point3D(0, 20, 3), Point3D(10, 20, 3), Point3D(10, 10, 3))
+pts_4 = (Point3D(10, 10, 3), Point3D(10, 20, 3), Point3D(20, 20, 3), Point3D(20, 10, 3))
+room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+room2d_3 = Room2D('Office3', Face3D(pts_3), 3)
+room2d_4 = Room2D('Office4', Face3D(pts_4), 3)
+story = Story('OfficeFloor', [room2d_1, room2d_2, room2d_3, room2d_4])
+story.solve_room_2d_adjacency(0.01)
+story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
+story.multiplier = 4
+building = Building('OfficeBuilding', [story])
+
+# assign energy properties
+for room in story.room_2ds:
+    room.properties.energy.program_type = office_program
+    room.properties.energy.add_default_ideal_air()
+
+# create the Model object
+model = Model('NewDevelopment', [building])
+```
+
+Once a Dragonfly Model has been created, it can be converted to a honeybee Model,
+which can then be converted to IDF format like so:
+```
+# create the dragonfly Model object
+model = Model('NewDevelopment', [building])
+
+# serialize the dragonfly Model to Honeybee Models and convert them to IDF
+hb_models = model.to_honeybee('Building', use_multiplier=False, tolerance=0.01)
+idfs = [hb_model.to.idf(hb_model) for hb_model in hb_models]
+```
+
+The dragonfly model can also be serialized to a geoJSON to be simulated with URBANopt
+```
+from ladybug.location import Location
+
+# create the dragonfly Model object
+model = Model('NewDevelopment', [building])
+
+# create a location for the geoJSON and write it to a folder
+location = Location('Boston', 'MA', 'USA', 42.366151, -71.019357)
+sim_folder = './tests/urbanopt_model'
+geojson, hb_model_jsons, hb_models = model.to.urbanopt(model, location, folder=sim_folder)
+```
+
 ## Local Development
 1. Clone this repo locally
 ```

--- a/dragonfly_energy/_extend_dragonfly.py
+++ b/dragonfly_energy/_extend_dragonfly.py
@@ -1,12 +1,14 @@
 # coding=utf-8
 from dragonfly.properties import ModelProperties, BuildingProperties, StoryProperties, \
     Room2DProperties, ContextShadeProperties
+import dragonfly.writer.model as model_writer
 
 from .properties.model import ModelEnergyProperties
 from .properties.building import BuildingEnergyProperties
 from .properties.story import StoryEnergyProperties
 from .properties.room2d import Room2DEnergyProperties
 from .properties.context import ContextShadeEnergyProperties
+from .writer import model_to_urbanopt
 
 
 # set a hidden energy attribute on each core geometry Property class to None
@@ -53,3 +55,7 @@ BuildingProperties.energy = property(building_energy_properties)
 StoryProperties.energy = property(story_energy_properties)
 Room2DProperties.energy = property(room2d_energy_properties)
 ContextShadeProperties.energy = property(context_energy_properties)
+
+
+# add model writer to urbanopt
+model_writer.urbanopt = model_to_urbanopt

--- a/dragonfly_energy/config.json
+++ b/dragonfly_energy/config.json
@@ -1,0 +1,5 @@
+{
+    "__comment__": "Add full paths to files (eg.C:/Urbanopt_test/Honeybee.rb).",
+    "mapper_path": "",
+    "urbanopt_gemfile_path": ""
+}

--- a/dragonfly_energy/config.py
+++ b/dragonfly_energy/config.py
@@ -1,0 +1,153 @@
+"""dragonfly_energy configurations.
+
+Import this into every module where access configurations are needed.
+
+Usage:
+
+.. code-block:: python
+
+    from dragonfly_energy.config import folders
+    print(folders.mapper_path)
+    folders.mapper_path = "C:/Urbanopt_test/Honeybee.rb"
+"""
+import honeybee_energy.config as hb_energy_config
+
+import os
+import json
+
+
+class Folders(object):
+    """Dragonfly_energy folders.
+
+    Args:
+        config_file: The path to the config.json file from which folders are loaded.
+            If None, the config.json module included in this package will be used.
+            Default: None.
+        mute: If False, the paths to the various folders will be printed as they
+            are found. If True, no printing will occur upon initialization of this
+            class. Default: True.
+
+    Properties:
+        * mapper_path
+        * urbanopt_gemfile_path
+        * config_file
+        * mute
+    """
+
+    def __init__(self, config_file=None, mute=True):
+        self.mute = bool(mute)  # set the mute value
+        self.config_file  = config_file  # load paths from the config JSON file
+
+    @property
+    def mapper_path(self):
+        """Get or set the path to the Ruby mapper used in URBANopt workflows.
+
+        This is the Ruby file that is used to map URBANopt geoJSON features to
+        honeybee model JSONs.
+        """
+        return self._mapper_path
+
+    @mapper_path.setter
+    def mapper_path(self, path):
+        if not path:  # check the default installation location
+            path = self._find_mapper_path()
+        if path:  # check that the mapper file exists in the path
+            assert os.path.isfile(path) and path.endswith('.rb'), \
+                '{} is not a valid path to a Ruby mapper file.'.format(path)
+        self._mapper_path = path  #set the mapper_path
+        if path and not self.mute:
+            print("Path to Mapper is set to: %s" % path)
+
+    @property
+    def urbanopt_gemfile_path(self):
+        """Get or set the path to the Gemfile used in URBANopt workflows.
+        
+        Setting this can be used to test newer versions of URBANopt with upgraded
+        dependencies in the Gemfile.
+        """
+        return self._urbanopt_gemfile_path
+
+    @urbanopt_gemfile_path.setter
+    def urbanopt_gemfile_path(self, path):
+        if not path:  # check the default installation location
+            path = self._find_urbanopt_gemfile_path()
+        if path:  # check that the Gemfile exists at the path
+            assert os.path.isfile(path), \
+                '{} is not a valid path to an URBANopt Gemfile.'.format(path)
+        self._urbanopt_gemfile_path = path  #set the urbanopt_gemfile_path
+        if path and not self.mute:
+            print("Path to URBANopt Gemfile is set to: %s" % path)
+
+    @property
+    def config_file(self):
+        """Get or set the path to the config.json file from which folders are loaded.
+
+        Setting this to None will result in using the config.json module included
+        in this package.
+        """
+        return self._config_file
+
+    @config_file.setter
+    def config_file(self, cfg):
+        if cfg is None:
+            cfg = os.path.join(os.path.dirname(__file__), 'config.json')
+        self._load_from_file(cfg)
+        self._config_file = cfg
+
+    def _load_from_file(self, file_path):
+        """Set all of the the properties of this object from a config JSON file.
+
+        Args:
+            file_path: Path to a JSON file containing the file paths. A sample of this
+                JSON is the config.json file within this package.
+        """
+        # check the default file path
+        assert os.path.isfile(str(file_path)), \
+            ValueError('No file found at {}'.format(file_path))
+
+        # set the default paths to be all blank
+        default_path = {
+            "mapper_path": r'',
+            "urbanopt_gemfile_path": r''
+        }
+
+        with open(file_path, 'r') as cfg:
+            try:
+                paths = json.load(cfg)
+            except Exception as e:
+                print('Failed to load paths from {}.\n{}'.format(file_path, e))
+            else:
+                for key, p in paths.items():
+                    if isinstance(key, list) or not key.startswith('__'):
+                        try:
+                            default_path[key] = p.strip()
+                        except AttributeError:
+                            default_path[key] = p
+
+        # set paths for mapper_path and urbanopt_gemfile_path
+        self.mapper_path = default_path["mapper_path"]
+        self.urbanopt_gemfile_path = default_path["urbanopt_gemfile_path"]
+
+    @staticmethod
+    def _find_mapper_path():
+        """Find the mapper path that is distributed with the energy-model-measure."""
+        measure_install = hb_energy_config.folders.energy_model_measure_path
+        if measure_install:
+            mapper_file = os.path.join(measure_install, 'files', 'Honeybee.rb')
+            if os.path.isfile(mapper_file):
+                return mapper_file
+        return None
+
+    @staticmethod
+    def _find_urbanopt_gemfile_path():
+        """Find the URBANopt Gemfile that's distributed with the energy-model-measure."""
+        measure_install = hb_energy_config.folders.energy_model_measure_path
+        if measure_install:
+            gem_file = os.path.join(measure_install, 'files', 'urbanopt_Gemfile')
+            if os.path.isfile(gem_file):
+                return gem_file
+        return None
+
+
+"""Object possesing all key folders within the configuration."""
+folders = Folders(mute=True)

--- a/dragonfly_energy/writer.py
+++ b/dragonfly_energy/writer.py
@@ -1,0 +1,96 @@
+# coding=utf-8
+"""Methods to write files for URBANopt simulation from a Model."""
+from ladybug_geometry.geometry2d import Point2D
+from ladybug.futil import nukedir, preparedir
+from honeybee.config import folders
+from honeybee.model import Model as hb_model
+
+import os
+import json
+
+
+def model_to_urbanopt(model, location, point=Point2D(0, 0), shade_distance=None,
+                      use_multiplier=True, folder=None, tolerance=0.01):
+    r"""Generate an URBANopt feature geoJSON and honeybee JSONs from a dragonfly Model.
+
+    Args:
+        model: A dragonfly Model for which an URBANopt feature geoJSON and
+            corresponding honeybee Model JSONs will be returned.
+        location: A ladybug Location object possessing longitude and latitude data.
+        point: A ladybug_geometry Point2D for where the location object exists
+            within the space of a scene. The coordinates of this point are
+            expected to be in the units of this Model. (Default: (0, 0)).
+        shade_distance: An optional number to note the distance beyond which other
+            objects' shade should not be exported into a given honeybee Model. This
+            is helpful for reducing the simulation run time of each Model when other
+            connected buildings are too far away to have a meaningful impact on
+            the results. If None, all other buildings will be included as context
+            shade in each and every Model. Set to 0 to exclude all neighboring
+            buildings from the resulting models. Default: None.
+        use_multiplier: If True, the multipliers on the Model's Stories will be
+            passed along to the generated Honeybee Room objects, indicating the
+            simulation will be run once for each unique room and then results
+            will be multiplied. If False, full geometry objects will be written
+            for each and every floor in the building that are represented through
+            multipliers and all resulting multipliers will be 1. Default: True
+        folder: An optional folder to be used as the root of the model's
+            URBANopt folder. If None, the files will be written into a sub-directory
+            of the honeybee-core default_simulation_folder. This sub-directory
+            is specifically: default_simulation_folder/[MODEL IDENTIFIER]
+        tolerance: The minimum distance between points at which they are
+            not considered touching. Default: 0.01, suitable for objects
+            in meters.
+
+    Returns:
+        A tuple with three values.
+
+        feature_geojson -- The path to an URBANopt feature geoJSON that has
+            been written by this method.
+
+        hb_model_jsons -- An array of file paths to honeybee Model JSONS that
+            correspond to the detailed_model_filename keys in the feature_geojson.
+        
+        hb_models -- An array of honeybee Model objects that were generated in
+            process of writing the URBANopt files.
+    """
+    # make sure the model is in meters and, if it's not, duplicate and scale it
+    if model.units != 'Meters':
+        conversion_factor = hb_model.conversion_factor_to_meters(model.units)
+        point = point.scale(conversion_factor)
+        if shade_distance is not None:
+            shade_distance = shade_distance * conversion_factor
+        model = model.duplicate()  # duplicate the model to avoid mutating the input
+        model.convert_to_units('Meters')
+
+    # prepare the folder for simulation
+    if folder is None:  # use the default simulation folder
+        folder = os.path.join(folders.default_simulation_folder, model.identifier)
+    nukedir(folder, True)  # get rid of anything that exists in the folder already
+    preparedir(folder)  # create the directory if it's not there
+
+    # prepare the folder into which honeybee Model JSONs will be written
+    hb_model_folder = os.path.join(folder, 'hb_json')  # folder for honeybee JSONs
+    preparedir(hb_model_folder)
+
+    # write out the geoJSON file from the model
+    geojson_dict = model.to_geojson_dict(location, point, folder, tolerance)
+    for feature_dict in geojson_dict['features']:  # add the detailed model filename
+        if feature_dict['properties']['type'] == 'Building':
+            bldg_id = feature_dict['properties']['id']
+            feature_dict['properties']['detailed_model_filename'] = \
+                        os.path.join(hb_model_folder, '{}.json'.format(bldg_id))
+    feature_geojson = os.path.join(folder, '{}.geojson'.format(model.identifier))
+    with open(feature_geojson, 'w') as fp:
+        json.dump(geojson_dict, fp, indent=4)
+
+    # write out the honeybee Model JSONS from the model
+    hb_model_jsons = []
+    hb_models = model.to_honeybee('Building', shade_distance, use_multiplier, tolerance)
+    for bldg_model in hb_models:
+        bld_path = os.path.join(hb_model_folder, '{}.json'.format(bldg_model.identifier))
+        model_dict = bldg_model.to_dict(triangulate_sub_faces=True)
+        with open(bld_path, 'w') as fp:
+            json.dump(model_dict, fp)
+        hb_model_jsons.append(bld_path)
+
+    return feature_geojson, hb_model_jsons, hb_models

--- a/tests/measure/edit_fraction_radiant_of_lighting_and_equipment/measure.rb
+++ b/tests/measure/edit_fraction_radiant_of_lighting_and_equipment/measure.rb
@@ -1,0 +1,96 @@
+# see the URL below for information on how to write OpenStudio measures
+# http://nrel.github.io/OpenStudio-user-documentation/reference/measure_writing_guide/
+
+# start the measure
+class EditFractionRadiantOfLightingAndEquipment < OpenStudio::Ruleset::ModelUserScript
+
+  # human readable name
+  def name
+    return "Edit Fraction Radiant of Lighting and Equipment"
+  end
+
+  # human readable description
+  def description
+    return "This measure replaces the 'Fraction Radiant' of all lights and equipment in the model with values that you specify. This is useful for thermal comfort studies where the percentage of heat transferred to the air is important."
+  end
+
+  # human readable description of modeling approach
+  def modeler_description
+    return "This measure replaces the 'Fraction Radiant' of all lights and equipment in the model with values that you specify."
+  end
+
+  # define the arguments that the user will input
+  def arguments(model)
+    args = OpenStudio::Ruleset::OSArgumentVector.new
+
+    #Fraction Radiant of Lights
+	lightFract = OpenStudio::Ruleset::OSArgument::makeDoubleArgument("lightsFractRad",false)
+	lightFract.setDisplayName("Lights Fraction Radiant")
+	lightFract.setDefaultValue(0.0)
+	args << lightFract
+	
+	#Fraction Radiant of Equipment
+	equipFract = OpenStudio::Ruleset::OSArgument::makeDoubleArgument("equipFractRad",false)
+	equipFract.setDisplayName("Equipment Fraction Radiant")
+	equipFract.setDefaultValue(0.0)
+	args << equipFract
+
+    return args
+  end
+
+  # define what happens when the measure is run
+  def run(model, runner, user_arguments)
+    super(model, runner, user_arguments)
+
+    # use the built-in error checking
+    if !runner.validateUserArguments(arguments(model), user_arguments)
+      return false
+    end
+
+    # assign the user inputs to variables
+    lightFract = runner.getStringArgumentValue("lightsFractRad", user_arguments).to_f
+	equipFract = runner.getStringArgumentValue("equipFractRad", user_arguments).to_f
+
+    # check the inputs for reasonableness
+    if lightFract < 0 or lightFract > 1
+      runner.registerError("Lights Fraction Radiant must be between 0 and 1.")
+      return false
+    end
+	if equipFract < 0 or equipFract > 1
+      runner.registerError("Equipment Fraction Radiant must be between 0 and 1.")
+      return false
+    end
+
+    # change the fraction radiant of all light and equipment objects in the model.
+	lightCount = 0
+	equipCount = 0
+	space_types = model.getSpaceTypes
+	space_types.each do |space_type|
+		lights = space_type.lights
+		lights.each do |light|
+			ldef = model.getLights(light.handle).get
+			finalDef = model.getLightsDefinition(ldef.lightsDefinition.handle).get
+			finalDef.setFractionRadiant(lightFract)
+			lightCount += 1
+		end
+		equips = space_type.electricEquipment
+		equips.each do |equip|
+			edef = model.getElectricEquipment(equip.handle).get
+			finalDef = model.getElectricEquipmentDefinition(edef.electricEquipmentDefinition.handle).get
+			finalDef.setFractionRadiant(equipFract)
+			equipCount += 1
+		end
+	end
+
+    # report final condition of model
+    runner.registerFinalCondition("The building finished with #{lightCount} light definitions with their fraction radiant set to #{lightFract}.")
+	runner.registerFinalCondition("The building finished with #{equipCount} equipment definitions with their fraction radiant set to #{equipFract}.")
+
+    return true
+
+  end
+  
+end
+
+# register the measure to be used by the application
+EditFractionRadiantOfLightingAndEquipment.new.registerWithApplication

--- a/tests/measure/edit_fraction_radiant_of_lighting_and_equipment/measure.xml
+++ b/tests/measure/edit_fraction_radiant_of_lighting_and_equipment/measure.xml
@@ -1,0 +1,75 @@
+<measure>
+  <schema_version>3.0</schema_version>
+  <name>edit_fraction_radiant_of_lighting_and_equipment</name>
+  <uid>8dc4dfa6-e4b9-404e-916f-d185af55cce0</uid>
+  <version_id>bd50a42d-62be-476e-90a1-31aa824f7525</version_id>
+  <version_modified>20171231T171740Z</version_modified>
+  <xml_checksum>628D6EBA</xml_checksum>
+  <class_name>EditFractionRadiantOfLightingAndEquipment</class_name>
+  <display_name>Edit Fraction Radiant of Lighting and Equipment</display_name>
+  <description>This measure replaces the 'Fraction Radiant' of all lights and equipment in the model with values that you specify. This is useful for thermal comfort studies where the percentage of heat transferred to the air is important.</description>
+  <modeler_description>This measure replaces the 'Fraction Radiant' of all lights and equipment in the model with values that you specify.</modeler_description>
+  <arguments>
+    <argument>
+      <name>lightsFractRad</name>
+      <display_name>Lights Fraction Radiant</display_name>
+      <type>Double</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>equipFractRad</name>
+      <display_name>Equipment Fraction Radiant</display_name>
+      <type>Double</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+  </arguments>
+  <outputs/>
+  <provenances/>
+  <tags>
+    <tag>Electric Lighting.Lighting Equipment</tag>
+  </tags>
+  <attributes>
+    <attribute>
+      <name>Measure Type</name>
+      <value>ModelMeasure</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Intended Software Tool</name>
+      <value>Apply Measure Now</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Intended Software Tool</name>
+      <value>OpenStudio Application</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Intended Software Tool</name>
+      <value>Parametric Analysis Tool</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Intended Use Case</name>
+      <value>Model Articulation</value>
+      <datatype>string</datatype>
+    </attribute>
+  </attributes>
+  <files>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>2.3.0</identifier>
+        <min_compatible>2.3.0</min_compatible>
+      </version>
+      <filename>measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>script</usage_type>
+      <checksum>C2F38416</checksum>
+    </file>
+  </files>
+</measure>


### PR DESCRIPTION
This commit completely refactors the (previously very hacky) way that we were running the URBANopt CLI.

Now, the dragonfly Model object has a writer to convert the model into an URBANopt geoJSON and linked honeybee model JSONs for each building. This is much cleaner than specifying .osm files in the URBANopt geoJSON `detailed_model_filename` keys since these .osms would have to be generated separately from geojson creation, making broken references a likely scenario in both scripting workflows and Grasshopper workflows.

After this writer method is run, we generate our own base workflow.osw that includes the `energy-model-measure` to translate the honeybee JSONs to OpenStudio models as part of the URBANopt run. This has the added benefit that we can include additional measures in this workflow after the model creation, allowing the user to include any measures they want with any input arguments they want.

So this will allow SOM to import the "Create ypical Building" measure to Grasshopper, specify which HVAC system they want, and include the measure in the URBANopt run.

While the tests are all done here, I cannot merge this PR in until I update the components in dragonfly-grasshopper.

@mostaphaRoudsari ,
I know that this commit has a lot of stuff that's specific to OpenStudio workflows and the URBANopt CLI that I am not expecting feedback on. But I just wanted you to be aware of this change since it's the first time I am adding a writer method to dragonfly (all the previous workflows were done with `to_honeybee` and `to_dict`).

Resolves https://github.com/ladybug-tools/dragonfly-core/issues/71