### PR TITLE
fix(gem): Change the gem name to honeybee-openstudio

### DIFF
--- a/dragonfly_energy/config.py
+++ b/dragonfly_energy/config.py
@@ -130,8 +130,8 @@ class Folders(object):
 
     @staticmethod
     def _find_mapper_path():
-        """Find the mapper path that is distributed with the energy-model-measure."""
-        measure_install = hb_energy_config.folders.energy_model_measure_path
+        """Find the mapper that is distributed with the honeybee-openstudio-gem."""
+        measure_install = hb_energy_config.folders.honeybee_openstudio_gem_path
         if measure_install:
             mapper_file = os.path.join(measure_install, 'files', 'Honeybee.rb')
             if os.path.isfile(mapper_file):
@@ -140,8 +140,8 @@ class Folders(object):
 
     @staticmethod
     def _find_urbanopt_gemfile_path():
-        """Find the URBANopt Gemfile that's distributed with the energy-model-measure."""
-        measure_install = hb_energy_config.folders.energy_model_measure_path
+        """Find the URBANopt Gemfile that's distributed with honeybee-openstudio-gem."""
+        measure_install = hb_energy_config.folders.honeybee_openstudio_gem_path
         if measure_install:
             gem_file = os.path.join(measure_install, 'files', 'urbanopt_Gemfile')
             if os.path.isfile(gem_file):

--- a/dragonfly_energy/run.py
+++ b/dragonfly_energy/run.py
@@ -78,8 +78,8 @@ def base_honeybee_osw(
     # assign the measure_paths to the osw_dict
     if 'measure_paths' not in osw_dict:
         osw_dict['measure_paths'] = []
-    if hb_energy_folders.energy_model_measure_path:  # pass the energy-model-measure path
-        m_dir = os.path.join(hb_energy_folders.energy_model_measure_path, 'measures')
+    if hb_energy_folders.honeybee_openstudio_gem_path:  # add honeybee-openstudio measure
+        m_dir = os.path.join(hb_energy_folders.honeybee_openstudio_gem_path, 'measures')
         osw_dict['measure_paths'].append(m_dir)
 
     # add any additional measures to the osw_dict

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 dragonfly-core==1.20.0
-honeybee-energy==1.44.7
+honeybee-energy==1.44.8


### PR DESCRIPTION
This commit is coordinated with this one over on the honeybee-openstudio0gem :
https://github.com/ladybug-tools/energy-model-measure/pull/105