### PR TITLE
fix(cli): Fix typo in CLI simulate command

### DIFF
--- a/dragonfly_energy/_extend_dragonfly.py
+++ b/dragonfly_energy/_extend_dragonfly.py
@@ -25,6 +25,7 @@ def model_energy_properties(self):
         self._energy = ModelEnergyProperties(self.host)
     return self._energy
 
+
 def building_energy_properties(self):
     if self._energy is None:
         self._energy = BuildingEnergyProperties(self.host)

--- a/dragonfly_energy/cli/__init__.py
+++ b/dragonfly_energy/cli/__init__.py
@@ -16,6 +16,7 @@ from .translate import translate
 def energy():
     pass
 
+
 # add sub-commands to energy
 energy.add_command(simulate)
 energy.add_command(translate)

--- a/dragonfly_energy/cli/simulate.py
+++ b/dragonfly_energy/cli/simulate.py
@@ -14,8 +14,6 @@ from ladybug.futil import preparedir
 from honeybee_energy.simulation.parameter import SimulationParameter
 from honeybee_energy.run import to_openstudio_osw, run_osw, run_idf, \
     output_energyplus_files
-from honeybee_energy.writer import energyplus_idf_version
-from honeybee_energy.config import folders
 
 import sys
 import os
@@ -28,6 +26,7 @@ _logger = logging.getLogger(__name__)
 @click.group(help='Commands for simulating Dragonfly JSON files in EnergyPlus.')
 def simulate():
     pass
+
 
 @simulate.command('model')
 @click.argument('model-json')
@@ -139,7 +138,7 @@ def simulate_model(model_json, epw_file, sim_par_json, obj_per_model, use_multip
                     if idf is None or not os.path.isfile(idf):
                         raise Exception('Running OpenStudio CLI failed.')
                     sql, eio, rdd, html, err = \
-                        _output_energyplus_files(os.path.dirname(idf))
+                        output_energyplus_files(os.path.dirname(idf))
                     if err is None or not os.path.isfile(err):
                         raise Exception('Running EnergyPlus failed.')
                     osms.append(osm)

--- a/dragonfly_energy/cli/translate.py
+++ b/dragonfly_energy/cli/translate.py
@@ -28,6 +28,7 @@ _logger = logging.getLogger(__name__)
 def translate():
     pass
 
+
 @translate.command('model-to-osm')
 @click.argument('model-json')
 @click.option('--sim-par-json', help='Full path to a honeybee energy SimulationParameter'
@@ -122,6 +123,7 @@ def model_to_osm(model_json, sim_par_json, obj_per_model, use_multiplier,
         sys.exit(1)
     else:
         sys.exit(0)
+
 
 @translate.command('model-to-idf')
 @click.argument('model-json')

--- a/dragonfly_energy/properties/building.py
+++ b/dragonfly_energy/properties/building.py
@@ -3,7 +3,6 @@
 from honeybee_energy.programtype import ProgramType
 from honeybee_energy.constructionset import ConstructionSet
 from honeybee_energy.hvac._base import _HVACSystem
-from honeybee_energy.hvac.idealair import IdealAirSystem
 
 from honeybee_energy.lib.constructionsets import generic_construction_set
 
@@ -102,7 +101,7 @@ class BuildingEnergyProperties(object):
             room_2d.properties.energy.program_type = program_type
 
     def set_all_room_2d_hvac(self, hvac):
-        """Set all children Room2Ds of this Buiding to have the same HVAC system.
+        """Set all children Room2Ds of this Building to have the same HVAC system.
 
         For an HVAC system that is intended to be applied across multiple zones
         (such as a VAVSystem), all Room2Ds will receive the same HVAC instance

--- a/dragonfly_energy/properties/model.py
+++ b/dragonfly_energy/properties/model.py
@@ -4,9 +4,7 @@ from dragonfly.extensionutil import model_extension_dicts
 
 from honeybee_energy.lib.constructionsets import generic_construction_set
 
-from honeybee_energy.constructionset import ConstructionSet
 from honeybee_energy.construction.air import AirBoundaryConstruction
-from honeybee_energy.programtype import ProgramType
 import honeybee_energy.properties.model as hb_model_properties
 
 

--- a/dragonfly_energy/properties/story.py
+++ b/dragonfly_energy/properties/story.py
@@ -3,7 +3,6 @@
 from honeybee_energy.programtype import ProgramType
 from honeybee_energy.constructionset import ConstructionSet
 from honeybee_energy.hvac._base import _HVACSystem
-from honeybee_energy.hvac.idealair import IdealAirSystem
 
 from honeybee_energy.lib.constructionsets import generic_construction_set
 

--- a/dragonfly_energy/writer.py
+++ b/dragonfly_energy/writer.py
@@ -78,7 +78,7 @@ def model_to_urbanopt(model, location, point=Point2D(0, 0), shade_distance=None,
         if feature_dict['properties']['type'] == 'Building':
             bldg_id = feature_dict['properties']['id']
             feature_dict['properties']['detailed_model_filename'] = \
-                        os.path.join(hb_model_folder, '{}.json'.format(bldg_id))
+                os.path.join(hb_model_folder, '{}.json'.format(bldg_id))
     feature_geojson = os.path.join(folder, '{}.geojson'.format(model.identifier))
     with open(feature_geojson, 'w') as fp:
         json.dump(geojson_dict, fp, indent=4)


### PR DESCRIPTION
I also fixed a bunch of other typos and PEP8 mistakes.