### PR TITLE
feat(room2d): Add the ability to assign operable windows to Room2D

### DIFF
--- a/dragonfly_energy/properties/building.py
+++ b/dragonfly_energy/properties/building.py
@@ -117,9 +117,11 @@ class BuildingEnergyProperties(object):
         assert isinstance(hvac, _HVACSystem), 'Expected HVACSystem for Building.' \
             'set_all_room_2d_hvac. Got {}'.format(type(hvac))
 
-        if not hvac.is_single_room:  # apply the same instance to all rooms
+        if not hvac.is_single_room:  # duplicate once; apply same instance to all rooms
+            new_hvac = hvac.duplicate()
+            new_hvac._identifier = '{}_{}'.format(hvac.identifier, self.host.identifier)
             for room_2d in self.host.unique_room_2ds:
-                room_2d.properties.energy.hvac = hvac
+                room_2d.properties.energy.hvac = new_hvac
         else:  # duplicate the HVAC instance as it is applied to rooms
             for i, room_2d in enumerate(self.host.unique_room_2ds):
                 new_hvac = hvac.duplicate()

--- a/dragonfly_energy/properties/story.py
+++ b/dragonfly_energy/properties/story.py
@@ -103,8 +103,9 @@ class StoryEnergyProperties(object):
         """Set all children Room2Ds of this Story to have the same HVAC system.
 
         For an HVAC system that is intended to be applied across multiple zones
-        (such as a VAVSystem), all Room2Ds will receive the same HVAC instance
-        as their HVAC system. In the case of an HVAC that can only be assigned
+        (such as a VAV system), all Room2Ds will receive the same HVAC instance,
+        which will be a duplicated version of the input such that the HVAC is
+        unique to the story. In the case of an HVAC that can only be assigned
         to individual zones (such as an IdealAirSystem), the input hvac will be
         duplicated and identified (with an integer appended to the end) for each
         Room2D to which is it applied.
@@ -116,9 +117,11 @@ class StoryEnergyProperties(object):
         assert isinstance(hvac, _HVACSystem), 'Expected HVACSystem for Story.' \
             'set_all_room_2d_hvac. Got {}'.format(type(hvac))
 
-        if not hvac.is_single_room:  # apply the same instance to all rooms
+        if not hvac.is_single_room:  # duplicate once; apply same instance to all rooms
+            new_hvac = hvac.duplicate()
+            new_hvac._identifier = '{}_{}'.format(hvac.identifier, self.host.identifier)
             for room_2d in self.host.room_2ds:
-                room_2d.properties.energy.hvac = hvac
+                room_2d.properties.energy.hvac = new_hvac
         else:  # duplicate the HVAC instance as it is applied to rooms
             for i, room_2d in enumerate(self.host.room_2ds):
                 new_hvac = hvac.duplicate()


### PR DESCRIPTION
This commit also improves the methods that assign HVAC systems to Stories and Buildings by having them duplicate the system to make it unique to that object.