### PR TITLE
fix(deps): Remove [cli] option in favor of making it a requirement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir ladybug_tools && touch ladybug_tools/config.json
 ENV PATH="/home/ladybugbot/.local/bin:${PATH}"
 COPY . dragonfly-energy
 RUN pip3 install setuptools wheel\
-    && pip3 install ./dragonfly-energy[cli]
+    && pip3 install ./dragonfly-energy
 
 # Set up working directory
 RUN mkdir -p /home/ladybugbot/run/simulation

--- a/README.md
+++ b/README.md
@@ -13,10 +13,6 @@ Dragonfly extension for energy simulation.
 
 `pip install dragonfly-energy`
 
-If you want to also include the command line interface try:
-
-`pip install -U dragonfly-energy[cli]`
-
 ## QuickStart
 
 ```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,13 +13,7 @@ Installation
 
 ``pip install -U dragonfly-energy``.
 
-If you want to also include the command line interface use:
-
-``pip install -U dragonfly-energy[cli]``.
-
 To check if the command line is installed correctly use ``dragonfly-energy --help``
-or ``dragonfly energy --help``
-
 
 CLI Docs
 ========

--- a/dragonfly_energy/cli/__init__.py
+++ b/dragonfly_energy/cli/__init__.py
@@ -1,11 +1,5 @@
 """dragonfly-energy commands which will be added to dragonfly command line interface."""
-
-try:
-    import click
-except ImportError:
-    raise ImportError(
-        'click is not installed. Try `pip install . [cli]` command.'
-    )
+import click
 
 from dragonfly.cli import main
 from .simulate import simulate
@@ -17,7 +11,7 @@ def energy():
     pass
 
 
-# add sub-commands to energy
+# add sub-commands for energy
 energy.add_command(simulate)
 energy.add_command(translate)
 

--- a/dragonfly_energy/cli/simulate.py
+++ b/dragonfly_energy/cli/simulate.py
@@ -1,14 +1,11 @@
 """dragonfly energy simulation running commands."""
-
-try:
-    import click
-except ImportError:
-    raise ImportError(
-        'click is not installed. Try `pip install . [cli]` command.'
-    )
+import click
+import sys
+import os
+import logging
+import json
 
 from dragonfly.model import Model
-
 from honeybee.config import folders
 from honeybee_energy.simulation.parameter import SimulationParameter
 from honeybee_energy.run import to_openstudio_osw, run_osw, run_idf, \
@@ -16,10 +13,6 @@ from honeybee_energy.run import to_openstudio_osw, run_osw, run_idf, \
 from ladybug.futil import preparedir
 from ladybug.epw import EPW
 
-import sys
-import os
-import logging
-import json
 
 _logger = logging.getLogger(__name__)
 

--- a/dragonfly_energy/cli/translate.py
+++ b/dragonfly_energy/cli/translate.py
@@ -1,11 +1,9 @@
 """dragonfly energy translation commands."""
-
-try:
-    import click
-except ImportError:
-    raise ImportError(
-        'click is not installed. Try `pip install . [cli]` command.'
-    )
+import click
+import sys
+import os
+import logging
+import json
 
 from ladybug.futil import preparedir
 from honeybee.config import folders as hb_folders
@@ -15,10 +13,6 @@ from honeybee_energy.writer import energyplus_idf_version
 from honeybee_energy.config import folders
 from dragonfly.model import Model
 
-import sys
-import os
-import logging
-import json
 
 _logger = logging.getLogger(__name__)
 

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,6 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=["tests"]),
     include_package_data=True,
     install_requires=requirements,
-    extras_require={
-        'cli': ['click==7.1.2', 'dragonfly-core[cli]==1.28.4']
-    },
     entry_points={
         "console_scripts": ["dragonfly-energy = dragonfly_energy.cli:energy"]
     },


### PR DESCRIPTION
We plan to put the click dependency and dragonfly-schema dependency lower in the tree, eliminating the need for the [cli] option