### PR TITLE
ci(deps): Loosen requirements in CI to work with new pip

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,8 @@ jobs:
       - name: install python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install dragonfly-core
+          pip install honeybee-energy
           pip install -r dev-requirements.txt
       - name: run tests
         run: python -m pytest --cov=. tests/
@@ -52,7 +53,8 @@ jobs:
       - name: install python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install dragonfly-core
+          pip install honeybee-energy
           pip install -r dev-requirements.txt
       - name: install semantic-release
         run:


### PR DESCRIPTION
It has just become too annoying that our auto-deployment never works when there's a change in honeybee-core or lower on the dependency tree. This will at least get the tests to pass and the deployment to PyPI to happen smoothly.