### PR TITLE
fix(docer): Include honeybee-energy-standards in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY LICENSE ${LIBRARYDIR}
 
 USER root
 RUN pip3 install --no-cache-dir setuptools wheel\
-    && pip3 install --no-cache-dir ${LIBRARYDIR} \
+    && pip3 install --no-cache-dir ${LIBRARYDIR}[standards] \
     && apt-get -y --purge remove git \
     && apt-get -y clean \
     && apt-get -y autoremove \

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,9 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=["tests"]),
     include_package_data=True,
     install_requires=requirements,
+    extras_require={
+        'standards': "honeybee-energy-standards==2.1.2"
+    },
     entry_points={
         "console_scripts": ["dragonfly-energy = dragonfly_energy.cli:energy"]
     },


### PR DESCRIPTION
This commit also adds an extra that allows people to get the standards with dragonfly-energy.