### PR TITLE
ci(coveralls): Remove coveralls

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,14 +26,7 @@ jobs:
           pip install honeybee-energy
           pip install -r dev-requirements.txt
       - name: run tests
-        run: python -m pytest --cov=. tests/
-      - name: run test coverage
-        if: ${{ matrix.python-version == 3.7 }}
-        run: |
-          coverage report
-          coveralls
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python -m pytest tests/
 
   deploy:
     name: Deploy to GitHub and PyPI


### PR DESCRIPTION
Their servers have gone down twice in the last month. It's just not worth it occasionally breaking our CI now that we know the core libraries are covered well.